### PR TITLE
Expose refreshTimers function to re-initialize the timers

### DIFF
--- a/CapabilityAgents/Alerts/include/Alerts/AlertScheduler.h
+++ b/CapabilityAgents/Alerts/include/Alerts/AlertScheduler.h
@@ -152,6 +152,12 @@ public:
     void shutdown();
 
     /**
+     * Refresh timers. This can be called if the system clock time changes to reset the timers so that they go
+     * off at the correct time
+     */
+    void refreshTimers();
+
+    /**
      * Utility method to get list of all alerts being tracked by @c AlertScheduler
      *
      * @return list of all alerts being tracked by @c AlertScheduler

--- a/CapabilityAgents/Alerts/include/Alerts/AlertsCapabilityAgent.h
+++ b/CapabilityAgents/Alerts/include/Alerts/AlertsCapabilityAgent.h
@@ -165,6 +165,12 @@ public:
      */
     void clearData() override;
 
+    /**
+     * Refresh timers. This can be called if the system clock time changes to reset the timers so that they go
+     * off at the correct time
+     */
+    void refreshTimers();
+
 private:
     /**
      * Constructor.

--- a/CapabilityAgents/Alerts/src/AlertScheduler.cpp
+++ b/CapabilityAgents/Alerts/src/AlertScheduler.cpp
@@ -327,6 +327,11 @@ void AlertScheduler::shutdown() {
     m_scheduledAlerts.clear();
 }
 
+void AlertScheduler::refreshTimers()
+{
+  setTimerForNextAlert();
+}
+
 void AlertScheduler::executeOnAlertStateChange(std::string alertToken, State state, std::string reason) {
     ACSDK_DEBUG9(LX("executeOnAlertStateChange").d("alertToken", alertToken).d("state", state).d("reason", reason));
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/CapabilityAgents/Alerts/src/AlertsCapabilityAgent.cpp
+++ b/CapabilityAgents/Alerts/src/AlertsCapabilityAgent.cpp
@@ -902,6 +902,11 @@ void AlertsCapabilityAgent::clearData() {
     result.wait();
 }
 
+void AlertsCapabilityAgent::refreshTimers() {
+  ACSDK_DEBUG9(LX("refreshTimers"));
+  m_alertScheduler.refreshTimers();
+}
+
 std::unordered_set<std::shared_ptr<avsCommon::avs::CapabilityConfiguration>> AlertsCapabilityAgent::
     getCapabilityConfigurations() {
     return m_capabilityConfigurations;


### PR DESCRIPTION
- The main problem here was that our system clock can jump if there's an NTP sync after the alexa client is
  already started up and we have timers saved to disk. When the Alexa client starts up, the AlertScheduler
  computes the delta in seconds between the current system clock and the target time, and starts a Timer
  utility that counts on a thread for that many seconds, then makes a callback to ring the alarm. If the
  system clock updates while this is happening, the timer doesn't reliably fire at the correct time.

- The workaround in this commit is to expose a "refresh" function, so that if a user of this API detects that
  their time has jumped, they can re-do the work of setting up a timer for the existing timers, so that they
  ring at the correct times