### PR TITLE
VIC-13106 Fix for UK alarms bug

### DIFF
--- a/AVSCommon/Utils/include/AVSCommon/Utils/Timing/TimeUtils.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/Timing/TimeUtils.h
@@ -42,8 +42,7 @@ public:
     /**
      * Convert tm struct to time_t in UTC time
      *
-     * This function is needed because mktime uses the current timezone. Hence, we calculate the current timezone
-     * difference, and adjust the converted time.
+     * This function is needed because mktime uses the current timezone. 
      *
      * @param utcTm time to be converted. This should be in UTC time
      * @param[out] ret The converted UTC time to time_t
@@ -114,7 +113,8 @@ private:
      * @param[out] ret Required pointer to object where the result will be saved.
      * @return Whether it succeeded to calculate the localtime offset.
      */
-    bool localtimeOffset(std::time_t* ret);
+    // ERROR PRONE:
+    // bool localtimeOffset(std::time_t* ret);
 
     /// Object used to safely access the system ctime functions.
     std::shared_ptr<SafeCTimeAccess> m_safeCTimeAccess;

--- a/AVSCommon/Utils/src/TimeUtils.cpp
+++ b/AVSCommon/Utils/src/TimeUtils.cpp
@@ -13,6 +13,24 @@
  * permissions and limitations under the License.
  */
 
+// PORTIONS LICENSED UNDER
+/**
+ *   Copyright 2011-2015 Quickstep Technologies LLC.
+ *   Copyright 2015 Pivotal Software, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ **/
+
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -116,22 +134,116 @@ static bool convertToLocalTimeT(const std::tm* timeStruct, std::time_t* ret) {
 TimeUtils::TimeUtils() : m_safeCTimeAccess{SafeCTimeAccess::instance()} {
 }
 
-bool TimeUtils::convertToUtcTimeT(const std::tm* utcTm, std::time_t* ret) {
-    std::time_t converted;
-    std::time_t offset;
+// BEGIN LICENSED UNDER APACHE FROM PIVOTAL SOFTWARE
+namespace {
+    constexpr std::time_t kSecondsInMinute = 60;
+    constexpr std::time_t kMinutesInHour = 60;
+    constexpr std::time_t kHoursInDay = 24;
+    constexpr std::time_t kDaysInYear = 365;
+    constexpr std::time_t kSecondsInHour = kSecondsInMinute * kMinutesInHour;
+    constexpr std::time_t kSecondsInDay = kSecondsInHour * kHoursInDay;
+    constexpr std::time_t kSecondsInYear = kDaysInYear * kSecondsInDay;
+    constexpr std::time_t kEpochYearBase = 1970;
+    constexpr std::time_t kTMYearBase = 1900;
+    constexpr std::time_t kDaysUptoMonth[] = {
+        0,
+        31,                                                    // Jan
+        31 + 28,                                               // Feb
+        31 + 28 + 31,                                          // Mar
+        31 + 28 + 31 + 30,                                     // Apr
+        31 + 28 + 31 + 30 + 31,                                // May
+        31 + 28 + 31 + 30 + 31 + 30,                           // Jun
+        31 + 28 + 31 + 30 + 31 + 30 + 31,                      // Jul
+        31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,                 // Aug
+        31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,            // Sep
+        31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,       // Oct
+        31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,  // Nov
+    };
+    constexpr std::time_t kDaysUptoMonthLeapYear[] = {
+        0,
+        31,                                                    // Jan
+        31 + 29,                                               // Feb
+        31 + 29 + 31,                                          // Mar
+        31 + 29 + 31 + 30,                                     // Apr
+        31 + 29 + 31 + 30 + 31,                                // May
+        31 + 29 + 31 + 30 + 31 + 30,                           // Jun
+        31 + 29 + 31 + 30 + 31 + 30 + 31,                      // Jul
+        31 + 29 + 31 + 30 + 31 + 30 + 31 + 31,                 // Aug
+        31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30,            // Sep
+        31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,       // Oct
+        31 + 29 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,  // Nov
+    };
 
+    inline bool IsLeapYear(std::time_t year) {
+      // year is base 1900.
+      const bool common_year =
+          ((year & 3) != 0) ||
+          (((year + kTMYearBase) % 100 == 0) && ((year + kTMYearBase) % 400 != 0));
+      return !common_year;
+    }
+
+    constexpr std::time_t kPosBase4 = (kEpochYearBase + 3) % 4;
+    constexpr std::time_t kPosBase100 = (kEpochYearBase + 99) % 100;
+    constexpr std::time_t kPosBase400 = (kEpochYearBase + 399) % 400;
+    static_assert(static_cast<std::time_t>(-1) / 2 == 0,
+                  "Rounding towards 0 not guaranteed.");
+    // Negative bases will be similar as positive, if division rounds to negative
+    // infinity.
+    constexpr std::time_t kNegBase4 = 4 - (kEpochYearBase % 4);
+    constexpr std::time_t kNegBase100 = 100 - (kEpochYearBase % 100);
+    constexpr std::time_t kNegBase400 = 400 - (kEpochYearBase % 400);
+
+    // Number of leap days since 1970.
+    inline std::time_t NumLeapDays(std::time_t year) {
+      // year is base 1970.
+      if (year >= 0) {
+        return ((year + kPosBase4) / 4) - ((year + kPosBase100) / 100) +
+               ((year + kPosBase400) / 400);
+      } else {
+        return ((year - kNegBase4) / 4) - ((year - kNegBase100) / 100) +
+               ((year - kNegBase400) / 400);
+      }
+    }
+
+}  // namespace
+
+std::time_t timegmCustom(const struct std::tm *tm) {
+  const std::time_t years_since_epoch =
+      tm->tm_year + kTMYearBase - kEpochYearBase;
+  std::time_t time =
+      years_since_epoch * kSecondsInYear +
+      NumLeapDays(years_since_epoch) * kSecondsInDay;  // Account for leap days.
+
+  // Account for months in current year.
+  time += IsLeapYear(tm->tm_year)
+              ? kDaysUptoMonthLeapYear[tm->tm_mon] * kSecondsInDay
+              : kDaysUptoMonth[tm->tm_mon] * kSecondsInDay;
+  // Account for days in current month, hours-mins-seconds in current day.
+  time += (tm->tm_mday - 1) * kSecondsInDay + (tm->tm_hour * kSecondsInHour) +
+          (tm->tm_min * kSecondsInMinute) + tm->tm_sec;
+  return time;
+}
+// END LICENSED UNDER APACHE FROM PIVOTAL SOFTWARE
+
+bool TimeUtils::convertToUtcTimeT(const std::tm* utcTm, std::time_t* ret) {
     if (ret == nullptr) {
         ACSDK_ERROR(LX("convertToUtcTimeT").m("return variable is null"));
         return false;
     }
 
-    if (!convertToLocalTimeT(utcTm, &converted) || !localtimeOffset(&offset)) {
-        ACSDK_ERROR(LX("convertToUtcTimeT").m("failed to convert to local time"));
-        return false;
-    }
-
+    // ORIGINAL METHOD IS ERROR PRONE:
+    // std::time_t converted;
+    // std::time_t offset;
+    // if (!convertToLocalTimeT(utcTm, &converted) || !localtimeOffset(&offset)) {
+    //     ACSDK_ERROR(LX("convertToUtcTimeT").m("failed to convert to local time"));
+    //     return false;
+    // }
+    //
     // adjust converted time
-    *ret = converted - offset;
+    // *ret = converted - offset;
+
+    *ret = timegmCustom(utcTm);
+
     return true;
 }
 
@@ -254,23 +366,24 @@ bool TimeUtils::convertTimeToUtcIso8601Rfc3339(
     return true;
 }
 
-bool TimeUtils::localtimeOffset(std::time_t* ret) {
-    static const std::chrono::time_point<std::chrono::system_clock> timePoint{std::chrono::hours(24)};
-    auto fixedTime = std::chrono::system_clock::to_time_t(timePoint);
+// ERROR PRONE:
+// bool TimeUtils::localtimeOffset(std::time_t* ret) {
+//     static const std::chrono::time_point<std::chrono::system_clock> timePoint{std::chrono::hours(24)};
+//     auto fixedTime = std::chrono::system_clock::to_time_t(timePoint);
 
-    std::tm utcTm;
-    std::time_t utc;
-    std::tm localTm;
-    std::time_t local;
-    if (!m_safeCTimeAccess->getGmtime(fixedTime, &utcTm) || !convertToLocalTimeT(&utcTm, &utc) ||
-        !m_safeCTimeAccess->getLocaltime(fixedTime, &localTm) || !convertToLocalTimeT(&localTm, &local)) {
-        ACSDK_ERROR(LX("localtimeOffset").m("cannot retrieve tm struct"));
-        return false;
-    }
+//     std::tm utcTm;
+//     std::time_t utc;
+//     std::tm localTm;
+//     std::time_t local;
+//     if (!m_safeCTimeAccess->getGmtime(fixedTime, &utcTm) || !convertToLocalTimeT(&utcTm, &utc) ||
+//         !m_safeCTimeAccess->getLocaltime(fixedTime, &localTm) || !convertToLocalTimeT(&localTm, &local)) {
+//         ACSDK_ERROR(LX("localtimeOffset").m("cannot retrieve tm struct"));
+//         return false;
+//     }
 
-    *ret = utc - local;
-    return true;
-}
+//     *ret = utc - local;
+//     return true;
+// }
 
 }  // namespace timing
 }  // namespace utils


### PR DESCRIPTION
Setting a timer with the device timezone set to Europe/London results
in a 1 hour delay. This is because the SDK's approach to converting
from a std::tm to std::time_t can be tricked by daylight savings time.
Common internet suggestions are to use timegm (GNU'd), set the TZ env
variable prior to calling mktime (not thread safe), or doing the math
manually.
This uses some code from Quickstep to do the conversion manually.

The bug is tracked in avs-device-sdk issue 1183, but no solution is
provided yet.